### PR TITLE
Chacha20 poly1305

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,31 +28,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
-]
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +208,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +253,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -322,15 +322,6 @@ dependencies = [
  "generic-array",
  "rand_core",
  "typenum",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -495,16 +486,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
-]
-
-[[package]]
-name = "ghash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
-dependencies = [
- "opaque-debug",
- "polyval",
 ]
 
 [[package]]
@@ -680,8 +661,8 @@ dependencies = [
 name = "i6-pack"
 version = "0.1.17"
 dependencies = [
- "aes-gcm",
  "argon2",
+ "chacha20poly1305",
  "clap",
  "hmac",
  "num_cpus",
@@ -1069,12 +1050,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
-name = "polyval"
-version = "0.6.2"
+name = "poly1305"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cfg-if",
  "cpufeatures",
  "opaque-debug",
  "universal-hash",

--- a/i6-pack/Cargo.toml
+++ b/i6-pack/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 clap = "4"
 tar = "0.4"
 zstd = {version = "0.13", features = ["zstdmt"]}
-aes-gcm = "0.10"
+chacha20poly1305 = "0.10"
 rand = "0.8"
 hmac = "0.12"
 uuid = {version = "1", features = ["v4"]}

--- a/tooling/ci.sh
+++ b/tooling/ci.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
+
+# Deps
+# cargo install --locked cargo-audit cargo-edit cargo-udeps cargo-geiger cargo-crev cargo-deny
+
 set -Eeuo pipefail
 
 ci () {
-  # cargo install --locked cargo-audit cargo-edit cargo-udeps cargo-geiger cargo-crev cargo-deny
 
   cargo audit
   cargo upgrade --verbose

--- a/tooling/ci.sh
+++ b/tooling/ci.sh
@@ -2,6 +2,8 @@
 set -Eeuo pipefail
 
 ci () {
+  # cargo install --locked cargo-audit cargo-edit cargo-udeps cargo-geiger cargo-crev cargo-deny
+
   cargo audit
   cargo upgrade --verbose
   cargo update --verbose

--- a/tooling/prepare_release.sh
+++ b/tooling/prepare_release.sh
@@ -5,6 +5,9 @@
 # ./prepare_release.sh 0.1.25
 # ```
 
+# Deps
+# cargo install --locked git-cliff
+
 set -Eeuo pipefail
 
 ci () {


### PR DESCRIPTION
Change from aes256-gcm to chacha20 poly1305.

The primary reasoning behind this is that aes256-gcm has a 64GB limit per key or nonce [0].

i6 pack is primarily intended to be used for compressing and encrypting backups, and thus we will be hitting this 64GB limit.
We are not looking to increase complexity by implementing rotating keys / nonces, and thus other cipher suites were considered.
In looking for other available cipher suites, chacha20 poly1305 seems to cover most of the needs of this library, and thus is chosen.

0 - https://crypto.stackexchange.com/questions/31793/plain-text-size-limits-for-aes-gcm-mode-just-64gb